### PR TITLE
Fix AppVeyor build for .NET standard

### DIFF
--- a/api-client-shared.sln
+++ b/api-client-shared.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2015
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api_client_shared", "api-client-shared/api-client-shared.csproj", "{13C9281C-5A37-4E4A-A461-B3CADA8C5C61}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@
       .\appveyor-deploy\BuildPreamble.ps1         
   build:
         verbosity: minimal
-  image: Visual Studio 2015
+  image: Visual Studio 2017
   before_test:
   - ps: >-
       .\appveyor-deploy\TestPreamble.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,9 @@
   install:
     - git submodule update --init --recursive   
   before_build:
-  - ps: >-
+  - ps: |
       .\appveyor-deploy\BuildPreamble.ps1         
+      nuget restore
   build:
         verbosity: minimal
   image: Visual Studio 2017


### PR DESCRIPTION
`# Visual Studio 2015` in `.sln` file. It can be 2017 too, just not 2013 to avoid msbuild 12. Other changes are self-explaining.
  