### PR TITLE
Multi-targeting: .Net Framework 4.5 og .Net Standard 2.0

### DIFF
--- a/Digipost.Api.Client.Shared.Tests/Digipost.Api.Client.Shared.Tests.csproj
+++ b/Digipost.Api.Client.Shared.Tests/Digipost.Api.Client.Shared.Tests.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Digipost.Api.Client.Shared/Digipost.Api.Client.Shared.csproj
+++ b/Digipost.Api.Client.Shared/Digipost.Api.Client.Shared.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <None Update="Resources/**/*" CopyToOutputDirectory="PreserveNewest" />

--- a/api-client-shared.nuspec
+++ b/api-client-shared.nuspec
@@ -16,7 +16,11 @@
     <files>
         <file 
             src="Digipost.Api.Client.Shared\bin\Release\netstandard2.0\Digipost.Api.Client.Shared.dll" 
-            target="lib\netstandard2\Digipost.Api.Client.Shared.dll" 
+            target="lib\netstandard2.0" 
+        />
+        <file 
+            src="Digipost.Api.Client.Shared\bin\Release\net45\Digipost.Api.Client.Shared.dll" 
+            target="lib\net45" 
         />
     </files>
 </package>


### PR DESCRIPTION
Legger til multi-targeting for å gjøre det enklere å få lagt til tilsvarende i pakker som er avhengig av denne. Dette er ønskelig for å kunne innføre støtte for .Net Standard uten å ødelegge for konsumenter som er avhengig av at støtte for .Net Framework beholdes.

Valgte .Net Framework 4.5 da dette er versjonen som er støttet i siste versjon av pakken difi-sikker-digital-post-klient. Testprosjektet bygges for .Net Framework 4.5.2 (i tillegg til .Net Standard 2.0), da dette er siste versjon som er støttet i testrammeverket som brukes. "dotnet test" kan dermed brukes til å kjøre testene under begge platformene.

